### PR TITLE
Extend the league

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "require": {
     "php": "^7.1",
+    "ext-json": "*",
     "ext-mbstring": "*",
     "johngrogg/ics-parser": "*",
     "guzzlehttp/guzzle": "*",

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -249,6 +249,17 @@ teams:
   "Tonga":
     stadium: Teufaiva Sport Stadium
   "United States":
+  "Timisoara Saracens":
+    alias:
+      - Timișoara Saracens
+    stadium: Stadionul Dan Păltinișanu
+  "Enisei-STM":
+    alias:
+      - Yenisey-STM Krasnoyarsk
+  "Krasny Yar":
+    alias:
+      - Krasny Yar Krasnoyarsk
+    stadium: Krasny Yar Stadium
 
 leagues:
   - name: Aviva Premiership
@@ -468,3 +479,46 @@ leagues:
       - Stade Toulousain
       - Ulster
       - Wasps
+  - name: Challenge Cup
+    url: challenge_cup
+    calendar:
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/european-challenge-cup/results
+        type: bbc
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/european-challenge-cup/fixtures
+        type: bbc
+    table:
+      url: https://www.bbc.co.uk/sport/rugby-union/european-challenge-cup/table
+      type: bbc
+    teams:
+      - ASM Clermont Auvergne
+      - Atlantique Stade Rochelais
+      - Cardiff Blues
+      - Benetton
+      - Bristol
+      - Club Athlétique Brive Corrèze Limousin
+      - Connacht
+      - Dragons
+      - Edinburgh
+      - Enisei-STM
+      - FC Grenoble
+      - Gloucester
+      - Harlequins
+      - Krasny Yar
+      - London Irish
+      - Lyon OU
+      - Newcastle Falcons
+      - Northampton Saints
+      - Ospreys
+      - Perpignan
+      - Sale Sharks
+      - Section Paloise
+      - Stade Français Paris
+      - Stade Toulousain
+      - SU Agen Lot-et-Garonne
+      - Timisoara Saracens
+      - Union Bordeaux Bègles
+      - Union Sportive Oyonnax Rugby
+      - Worcester
+      - Zebre

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -154,6 +154,48 @@ teams:
   "Blues":
     conference: New Zealand
     stadium: Eden Park
+  "ASM Clermont Auvergne":
+    alias:
+    - Clermont Auvergne
+    stadium: Parc des Sports Marcel Michelin
+  "Atlantique Stade Rochelais":
+    alias:
+    - Stade Rochelais
+    stadium: Stade Marcel-Deflandre
+  "Castres Olympique":
+    alias:
+      - Castres
+    stadium: Stade Pierre-Fabre
+  "FC Grenoble":
+    stadium: Stade des Alpes
+  "Lyon OU":
+    alias:
+      - Lyon Olympique Universitaire
+    stadium: Matmut Stadium de Gerland
+  "Montpellier":
+    alias:
+      - Montpellier Hérault
+    stadium: Altrad Stadium
+  "Perpignan":
+    stadium: Stade Aimé Giral
+  "Racing 92":
+    stadium: Paris La Défense Arena
+  "RC Toulonnais":
+    alias:
+    - Toulonnais
+    stadium: Stade Mayol
+  "Section Paloise":
+    stadium: Stade du Hameau
+  "Stade Français Paris":
+    alias:
+    - Stade Français
+    stadium: Stade Jean-Bouin
+  "Stade Toulousain":
+    stadium: Stade Ernest-Wallon
+  "SU Agen Lot-et-Garonne":
+    stadium: Stade Armandie
+  "Union Bordeaux Bègles":
+    stadium: Stade Chaban-Delmas
 
 leagues:
   - name: Aviva Premiership
@@ -240,3 +282,31 @@ leagues:
       - Stormers
       - Sunwolves
       - Waratahs
+
+  - name: French Top 14
+    url: top_14
+    calendar:
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/top-14/fixtures
+        type: bbc
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/top-14/results
+        type: bbc
+    table:
+      url: https://www.bbc.co.uk/sport/rugby-union/top-14/table
+      type: bbc
+    teams:
+      - ASM Clermont Auvergne
+      - Atlantique Stade Rochelais
+      - Castres Olympique
+      - FC Grenoble
+      - Lyon OU
+      - Montpellier
+      - Perpignan
+      - Racing 92
+      - RC Toulonnais
+      - Section Paloise
+      - Stade Français Paris
+      - Stade Toulousain
+      - SU Agen Lot-et-Garonne
+      - Union Bordeaux Bègles

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -181,6 +181,7 @@ leagues:
       - Gloucester
       - Newcastle Falcons
       - London Irish
+      - London Welsh
       - Worcester
 
   - name: Guiness Pro14

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -233,6 +233,11 @@ teams:
     stadium: Stade de France
   "Ireland":
     stadium: Aviva Stadium
+  "Australia":
+  "South Africa":
+  "Argentina":
+  "New Zealand":
+
 
 
 leagues:
@@ -369,3 +374,19 @@ leagues:
       - Italy
       - Scotland
       - Wales
+  - name: Rugby Championship
+    url: rugby_championship
+    calendar:
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/rugby-championship/fixtures
+        type: bbc
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/rugby-championship/results
+        type: bbc
+    table:
+      url: https://www.bbc.co.uk/sport/rugby-union/rugby-championship/table
+    teams:
+      - Argentina
+      - Australia
+      - New Zealand
+      - South Africa

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -107,6 +107,51 @@ teams:
       - Toyota Cheetahs
     conference: A
     stadium: Toyota stadium
+  "Bulls":
+    conference: South Africa
+    stadium: Loftus Versfeld
+  "Lions":
+    conference: South Africa
+    stadium: Emirates Airline Park
+  "Sharks":
+    conference: South Africa
+    stadium: Growthpoints Kings Park
+  "Stormers":
+    conference: South Africa
+    stadium: DHL Newlands
+  "Jaguares":
+    conference: South Africa
+    stadium: Estadio José Amalfitani
+  "Brumbies":
+    conference: Australia
+    stadium: GIO Stadium Canberra
+  "Rebels":
+    conference: Australia
+    stadium: AAMI Park
+  "Reds":
+    conference: Australia
+    stadium: Suncorp Stadium
+  "Sunwolves":
+    conference: Australia
+    stadium: Chichibunomiya Rugby Stadium
+  "Waratahs":
+    conference: Australia
+    stadium: Allianz Stadium
+  "Crusaders":
+    conference: New Zealand
+    stadium: AMI Stadium
+  "Hurricanes":
+    conference: New Zealand
+    stadium: Westpac Stadium
+  "Chiefs":
+    conference: New Zealand
+    stadium: FMG Stadium Waikato
+  "Highlanders":
+    conference: New Zealand
+    stadium: Forsyth Barr Stadium
+  "Blues":
+    conference: New Zealand
+    stadium: Eden Park
 
 leagues:
   - name: Aviva Premiership
@@ -162,3 +207,32 @@ leagues:
       - Cardiff Blues
       - Southern Kings
       - Cheetahs
+
+  - name: Super Rugby
+    url: super
+    calendar:
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/super-rugby/results
+        type: bbc
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/super-rugby/fixtures
+        type: bbc
+    table:
+      url: https://www.bbc.co.uk/sport/rugby-union/super-rugby/table
+      type: bbc
+    teams:
+      - Blues
+      - Brumbies
+      - Bulls
+      - Chiefs
+      - Crusaders
+      - Highlanders
+      - Hurricanes
+      - Jaguares
+      - Lions
+      - Rebels
+      - Reds
+      - Sharks
+      - Stormers
+      - Sunwolves
+      - Waratahs

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -57,10 +57,9 @@ teams:
   "Ospreys":
     conference: A
     stadium: Liberty Stadium
-  "Benneton":
+  "Benetton":
     alias:
       - Benetton Rugby
-      - Benetton
       - Benetton Treviso
       - Treviso
     conference: B
@@ -296,7 +295,7 @@ leagues:
       - Munster
       - Edinburgh
       - Ospreys
-      - Benneton
+      - Benetton
       - Scarlets
       - Ulster
       - Connacht
@@ -396,6 +395,7 @@ leagues:
         type: bbc
     table:
       url: https://www.bbc.co.uk/sport/rugby-union/rugby-championship/table
+      type: bbc
     teams:
       - Argentina
       - Australia
@@ -429,3 +429,42 @@ leagues:
       - Tonga
       - United States
       - Wales
+  - name: Champions Cup
+    url: champions_cup
+    calendar:
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/european-cup/fixtures
+        type: bbc
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/european-cup/results
+        type: bbc
+    table:
+      url: https://www.bbc.co.uk/sport/rugby-union/european-cup/table
+      type: bbc
+    teams:
+      - ASM Clermont Auvergne
+      - Atlantique Stade Rochelais
+      - Benetton
+      - Bath Rugby
+      - Cardiff Blues
+      - Castres Olympique
+      - Edinburgh
+      - Exeter Chiefs
+      - Glasgow
+      - Gloucester
+      - Harlequins
+      - Leicester Tigers
+      - Leinster
+      - Lyon OU
+      - Montpellier
+      - Munster
+      - Newcastle Falcons
+      - Northampton Saints
+      - Ospreys
+      - Racing 92
+      - RC Toulonnais
+      - Saracens
+      - Scarlets
+      - Stade Toulousain
+      - Ulster
+      - Wasps

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -157,20 +157,30 @@ teams:
   "ASM Clermont Auvergne":
     alias:
     - Clermont Auvergne
+    - Clermont
     stadium: Parc des Sports Marcel Michelin
   "Atlantique Stade Rochelais":
     alias:
     - Stade Rochelais
+    - La Rochelle
     stadium: Stade Marcel-Deflandre
   "Castres Olympique":
     alias:
       - Castres
     stadium: Stade Pierre-Fabre
+  "Club Athlétique Brive Corrèze Limousin":
+    alias:
+      - CA Brive
+      - Brive
+    stadium: Stade Amédée-Domenech
   "FC Grenoble":
+    alias:
+      - Grenoble
     stadium: Stade des Alpes
   "Lyon OU":
     alias:
       - Lyon Olympique Universitaire
+      - Lyon
     stadium: Matmut Stadium de Gerland
   "Montpellier":
     alias:
@@ -182,20 +192,35 @@ teams:
     stadium: Paris La Défense Arena
   "RC Toulonnais":
     alias:
-    - Toulonnais
+      - Toulonnais
+      - Toulon
+      - RCT
     stadium: Stade Mayol
   "Section Paloise":
+    alias:
+        - Pau
     stadium: Stade du Hameau
   "Stade Français Paris":
     alias:
-    - Stade Français
+      - Stade Français
     stadium: Stade Jean-Bouin
   "Stade Toulousain":
+    alias:
+      - Toulouse
     stadium: Stade Ernest-Wallon
   "SU Agen Lot-et-Garonne":
+    alias:
+      - Agen
     stadium: Stade Armandie
   "Union Bordeaux Bègles":
+    alias:
+      - Bordeaux
     stadium: Stade Chaban-Delmas
+  "Union Sportive Oyonnax Rugby":
+    alias:
+      - Oyonnax Rugby
+      - Oyonnax
+    stadium: Stade Charles-Mathon
 
 leagues:
   - name: Aviva Premiership
@@ -299,6 +324,7 @@ leagues:
       - ASM Clermont Auvergne
       - Atlantique Stade Rochelais
       - Castres Olympique
+      - Club Athlétique Brive Corrèze Limousin
       - FC Grenoble
       - Lyon OU
       - Montpellier
@@ -310,3 +336,4 @@ leagues:
       - Stade Toulousain
       - SU Agen Lot-et-Garonne
       - Union Bordeaux Bègles
+      - Union Sportive Oyonnax Rugby

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -221,6 +221,19 @@ teams:
       - Oyonnax Rugby
       - Oyonnax
     stadium: Stade Charles-Mathon
+  "England":
+    stadium: Twickenham
+  "Wales":
+    stadium: Millenium Stadium
+  "Scotland":
+    stadium: Murrayfield
+  "Italy":
+    stadium: Stadio Flaminio
+  "France":
+    stadium: Stade de France
+  "Ireland":
+    stadium: Aviva Stadium
+
 
 leagues:
   - name: Aviva Premiership
@@ -337,3 +350,22 @@ leagues:
       - SU Agen Lot-et-Garonne
       - Union Bordeaux Bègles
       - Union Sportive Oyonnax Rugby
+  - name: Six Nations
+    url: six_nations
+    calendar:
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/six-nations/fixtures
+        type: bbc
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/six-nations/results
+        type: bbc
+    table:
+      url: https://www.bbc.co.uk/sport/rugby-union/six-nations/table
+      type: bbc
+    teams:
+      - England
+      - France
+      - Ireland
+      - Italy
+      - Scotland
+      - Wales

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -237,8 +237,19 @@ teams:
   "South Africa":
   "Argentina":
   "New Zealand":
-
-
+  "Canada":
+  "Barbarians":
+  "Fiji":
+    stadium: ANZ National Stadium
+  "Georgia":
+    stadium: Mikheil Meskhi Stadium
+  "Japan":
+    stadium: Chichibunomiya Stadium
+  "Samoa":
+    stadium: Apia Park
+  "Tonga":
+    stadium: Teufaiva Sport Stadium
+  "United States":
 
 leagues:
   - name: Aviva Premiership
@@ -390,3 +401,31 @@ leagues:
       - Australia
       - New Zealand
       - South Africa
+  - name: International
+    url: international
+    calendar:
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/international-match/fixtures
+        type: bbc
+      -
+        url: https://www.bbc.co.uk/sport/rugby-union/international-match/results
+        type: bbc
+    teams:
+      - Argentina
+      - Australia
+      - Barbarians
+      - Canada
+      - England
+      - Fiji
+      - France
+      - Georgia
+      - Ireland
+      - Italy
+      - Japan
+      - New Zealand
+      - Samoa
+      - Scotland
+      - South Africa
+      - Tonga
+      - United States
+      - Wales

--- a/etc/data.yml
+++ b/etc/data.yml
@@ -33,6 +33,8 @@ teams:
       - Newcastle
     stadium: Kingston Park
   "Bristol":
+    alias:
+      - Bristol Bears
     stadium: Ashton Gate
   "London Irish":
     stadium: Madejski Stadium
@@ -168,6 +170,7 @@ leagues:
       type: bbc
     teams:
       - Bath Rugby
+      - Bristol
       - Northampton Saints
       - Exeter Chiefs
       - Saracens

--- a/src/Punkstar/RugbyFeed/Fixture.php
+++ b/src/Punkstar/RugbyFeed/Fixture.php
@@ -116,11 +116,19 @@ class Fixture
         $league = null
     ) {
 
-        $this->home_team = $home_team ? $league->getTeam($home_team) : null;
-        $this->away_team = $away_team ? $league->getTeam($away_team) : null;
+        $this->home_team = $league->getTeam($home_team);
+        $this->away_team = $league->getTeam($away_team);
         $this->home_score = $home_score;
         $this->away_score = $away_score;
         $this->kickoff = $kickoff;
+
+        if (is_null($this->home_team)) {
+            throw new \Exception("Found fixture with invalid home team name: " . $home_team);
+        }
+
+        if (is_null($this->away_team)) {
+            throw new \Exception("Found fixture with invalid away team name: " . $away_team);
+        }
 
         if ($location) {
             $this->location = trim($location);

--- a/src/Punkstar/RugbyFeed/FixtureProvider/BBCSport.php
+++ b/src/Punkstar/RugbyFeed/FixtureProvider/BBCSport.php
@@ -3,26 +3,42 @@
 namespace Punkstar\RugbyFeed\FixtureProvider;
 
 use nokogiri;
-use Punkstar\RugbyFeed\DataManager;
 use Punkstar\RugbyFeed\FileManager;
 use Punkstar\RugbyFeed\Fixture;
 use Punkstar\RugbyFeed\FixtureProvider;
+use Punkstar\RugbyFeed\League;
 
 class BBCSport implements FixtureProvider
 {
 
-    private $html;
     /**
-     * @var null
+     * @var string
      */
-    private $dataManager;
+    private $html;
 
-    public function __construct($html, $dataManager = null)
+    /**
+     * @var League
+     */
+    private $league;
+
+    /**
+     * BBCSport constructor.
+     *
+     * @param string $html
+     * @param League $league
+     */
+    public function __construct(string $html, League $league)
     {
         $this->html = $html;
-        $this->dataManager = $dataManager ?? new DataManager();
+        $this->league = $league;
     }
 
+    /**
+     * Parse fixtures
+     *
+     * @return array|Fixture[]
+     * @throws \Exception
+     */
     public function getFixtures()
     {
         $document = new nokogiri($this->html);
@@ -63,10 +79,11 @@ class BBCSport implements FixtureProvider
                 $fixtures[] = new Fixture(
                     trim($home_team),
                     trim($away_team),
-                    $home_score ?? null,
-                    $away_score ?? null,
+                    isset($home_score) ? trim($home_score) : null,
+                    isset($away_score) ? trim($away_score) : null,
                     null,
-                    strtotime(trim($kickoff))
+                    strtotime(trim($kickoff)),
+                    $this->league
                 );
             }
 
@@ -77,14 +94,17 @@ class BBCSport implements FixtureProvider
     }
 
     /**
-     * @param $url
+     * Get fixture parser from URL
+     *
+     * @param string $url
+     * @param League $league
      *
      * @throws \Exception
      * @return BBCSport
      */
-    public static function fromUrl($url, $dataManager = null)
+    public static function fromUrl($url, $league)
     {
         $fm = new FileManager();
-        return new self($fm->getFileFromUrl($url), $dataManager);
+        return new self($fm->getFileFromUrl($url), $league);
     }
 }

--- a/src/Punkstar/RugbyFeed/FixtureProvider/BBCSport.php
+++ b/src/Punkstar/RugbyFeed/FixtureProvider/BBCSport.php
@@ -35,8 +35,14 @@ class BBCSport implements FixtureProvider
 
             $fixtureGroup = $fixtureGroups->current();
 
+            // Loop through list of fixtures on date
             foreach ($fixtureGroup['li'] as $fixtureRow) {
-                $fixtureRowCore = $fixtureRow['a'][0]['article'][0]['div'][0]['span'];
+                // Should have link, but may not if game is post-poned
+                if (isset($fixtureRow['a'])) {
+                    $fixtureRowCore = $fixtureRow['a'][0]['article'][0]['div'][0]['span'];
+                } else {
+                    $fixtureRowCore = $fixtureRow['article'][0]['div'][0]['span'];
+                }
 
                 if (count($fixtureRowCore) == 2) {
                     // Result

--- a/src/Punkstar/RugbyFeed/FixtureProvider/BBCSport.php
+++ b/src/Punkstar/RugbyFeed/FixtureProvider/BBCSport.php
@@ -77,13 +77,13 @@ class BBCSport implements FixtureProvider
                 }
 
                 $fixtures[] = new Fixture(
+                    $this->league,
                     trim($home_team),
                     trim($away_team),
+                    strtotime(trim($kickoff)),
                     isset($home_score) ? trim($home_score) : null,
                     isset($away_score) ? trim($away_score) : null,
-                    null,
-                    strtotime(trim($kickoff)),
-                    $this->league
+                    null
                 );
             }
 

--- a/src/Punkstar/RugbyFeed/FixtureProvider/ICal.php
+++ b/src/Punkstar/RugbyFeed/FixtureProvider/ICal.php
@@ -5,29 +5,46 @@ namespace Punkstar\RugbyFeed\FixtureProvider;
 use Punkstar\RugbyFeed\FileManager;
 use Punkstar\RugbyFeed\Fixture;
 use Punkstar\RugbyFeed\FixtureProvider;
+use Punkstar\RugbyFeed\League;
 
 class ICal implements FixtureProvider
 {
-    protected $ical_file;
-    
-    public function __construct($icalData)
+    private $ical_file;
+    private $league;
+
+    /**
+     * ICal constructor.
+     *
+     * @param string $icalData
+     * @param League $league
+     *
+     */
+    public function __construct($icalData, $league)
     {
         $filename = tempnam("/tmp", "ICAL");
         
         file_put_contents($filename, $icalData);
         
         $this->ical_file = $filename;
-    }
-    
-    public static function fromUrl($url)
-    {
-        $fm = new FileManager();
-        
-        return new self($fm->getFileFromUrl($url));
+        $this->league = $league;
     }
 
     /**
-     * @return Fixture[]
+     * @param string $url
+     * @param League $league
+     *
+     * @return ICal
+     */
+    public static function fromUrl($url, $league)
+    {
+        $fm = new FileManager();
+        
+        return new self($fm->getFileFromUrl($url), $league);
+    }
+
+    /**
+     * @return array|Fixture[]
+     * @throws \Exception
      */
     public function getFixtures()
     {
@@ -37,7 +54,7 @@ class ICal implements FixtureProvider
         $events = array();
         
         foreach ($raw_events as $raw_event) {
-            $events[] = Fixture::buildFromICalEvent($raw_event);
+            $events[] = Fixture::buildFromICalEvent($raw_event, $this->league);
         }
         
         return $events;

--- a/src/Punkstar/RugbyFeed/FixtureSet.php
+++ b/src/Punkstar/RugbyFeed/FixtureSet.php
@@ -38,11 +38,14 @@ class FixtureSet
      */
     public function getEventsFromTeam(Team $team)
     {
-        $events = array();
+        $events = [];
 
         foreach ($this->getFixtures() as $event)
         {
-            if ($team->isAliasedTo($event->getAwayTeam()->getName()) || $team->isAliasedTo($event->getHomeTeam()->getName())) {
+            if (is_null($event->getAwayTeam()) || is_null($event->getHomeTeam())) {
+                var_dump($event); exit;
+            }
+            if ($team->getName() == $event->getAwayTeam()->getName() || $team->getName() == $event->getHomeTeam()->getName()) {
                 $events[] = $event;
             }
         }

--- a/src/Punkstar/RugbyFeed/FixtureSet.php
+++ b/src/Punkstar/RugbyFeed/FixtureSet.php
@@ -42,9 +42,6 @@ class FixtureSet
 
         foreach ($this->getFixtures() as $event)
         {
-            if (is_null($event->getAwayTeam()) || is_null($event->getHomeTeam())) {
-                var_dump($event); exit;
-            }
             if ($team->getName() == $event->getAwayTeam()->getName() || $team->getName() == $event->getHomeTeam()->getName()) {
                 $events[] = $event;
             }

--- a/src/Punkstar/RugbyFeed/League.php
+++ b/src/Punkstar/RugbyFeed/League.php
@@ -4,16 +4,11 @@ namespace Punkstar\RugbyFeed;
 
 class League
 {
-//    public function getCalendarUrl();
-//    public function getTeams();
-//    public function getCalendar();
-//    public function getUrlKey();
-    
     protected $teams;
     protected $data;
     protected $fixtures;
     protected $table;
-    
+
     public function __construct($data, array $teams, FixtureSet $fixtures, Table $table)
     {
         $this->data = $data;
@@ -21,12 +16,12 @@ class League
         $this->fixtures = $fixtures;
         $this->table = $table;
     }
-    
+
     public function getName()
     {
         return $this->data['name'] ?? 'unknown';
     }
-    
+
     /**
      * @return string
      */
@@ -34,7 +29,7 @@ class League
     {
         return $this->data['url'] ?? 'unknown';
     }
-    
+
     /**
      * @return Team[]
      */
@@ -42,7 +37,7 @@ class League
     {
         return $this->teams;
     }
-    
+
     /**
      * @param $teamSearchString
      * @return Team
@@ -54,10 +49,10 @@ class League
                 return $team;
             }
         }
-        
+
         return null;
     }
-    
+
     /**
      * @param $searchString
      * @return bool
@@ -65,10 +60,10 @@ class League
     public function isAliasedTo($searchString)
     {
         $aliases = array_map('strtolower', [$this->getName(), $this->getUrlKey()]);
-        
+
         return in_array($searchString, $aliases);
     }
-    
+
     /**
      * @return Fixture[]
      */
@@ -76,7 +71,7 @@ class League
     {
         return $this->fixtures->getFixtures();
     }
-    
+
     /**
      * @return Fixture[]
      */
@@ -84,7 +79,7 @@ class League
     {
         return $this->fixtures->getEventsFromTeam($teamSearchString);
     }
-    
+
     /**
      * @return Table
      */
@@ -92,47 +87,4 @@ class League
     {
         return $this->table;
     }
-
-    //
-//    /**
-//     * @return Team[]
-//     */
-//    public function getTeams()
-//    {
-//        $inited = array();
-//
-//        foreach ($this->teams as $team) {
-//            $inited[] = Team::build($team);
-//        }
-//
-//        return $inited;
-//    }
-//
-//    public function getCalendarUrl()
-//    {
-//        return $this->calendar_url;
-//    }
-//
-//    public function getCalendar()
-//    {
-//        return Calendar::fromUrl($this->getCalendarUrl());
-//    }
-//
-//    public function getFixtures()
-//    {
-//        return $this->getCalendar()->getEvents();
-//    }
-//
-//    public function getUrlKey()
-//    {
-//        return $this->url_key;
-//    }
-//
-//    public function getTable()
-//    {
-//        $bbc_sport_parser = BBCSportTableParser::fromUrl($this->table_url);
-//        $table = new Table($bbc_sport_parser->getRows());
-//
-//        return $table;
-//    }
 }

--- a/src/Punkstar/RugbyFeed/League.php
+++ b/src/Punkstar/RugbyFeed/League.php
@@ -110,7 +110,7 @@ class League
      */
     public function isAliasedTo($searchString)
     {
-        $aliases = array_map('strtolower', [$this->getName(), $this->getUrlKey()]);
+        $aliases = array_map('mb_strtolower', [$this->getName(), $this->getUrlKey()]);
 
         return in_array($searchString, $aliases);
     }

--- a/src/Punkstar/RugbyFeed/League.php
+++ b/src/Punkstar/RugbyFeed/League.php
@@ -4,12 +4,13 @@ namespace Punkstar\RugbyFeed;
 
 class League
 {
+
     protected $teams;
     protected $data;
     protected $fixtures;
     protected $table;
 
-    public function __construct($data, array $teams, FixtureSet $fixtures, Table $table)
+    public function __construct($data, array $teams, FixtureSet $fixtures = null, Table $table = null)
     {
         $this->data = $data;
         $this->teams = $teams;
@@ -40,6 +41,7 @@ class League
 
     /**
      * @param $teamSearchString
+     *
      * @return Team
      */
     public function getTeam($teamSearchString)
@@ -55,6 +57,7 @@ class League
 
     /**
      * @param $searchString
+     *
      * @return bool
      */
     public function isAliasedTo($searchString)
@@ -73,11 +76,21 @@ class League
     }
 
     /**
+     * @param FixtureSet $fixtures
+     */
+    public function setFixtures(FixtureSet $fixtures)
+    {
+        $this->fixtures = $fixtures;
+    }
+
+    /**
+     * @param Team $team
+     *
      * @return Fixture[]
      */
-    public function getFixturesForTeam($teamSearchString)
+    public function getFixturesForTeam($team)
     {
-        return $this->fixtures->getEventsFromTeam($teamSearchString);
+        return $this->fixtures->getEventsFromTeam($team);
     }
 
     /**
@@ -86,5 +99,13 @@ class League
     public function getTable()
     {
         return $this->table;
+    }
+
+    /**
+     * @param Table $table
+     */
+    public function setTable($table)
+    {
+        $this->table = $table;
     }
 }

--- a/src/Punkstar/RugbyFeed/League.php
+++ b/src/Punkstar/RugbyFeed/League.php
@@ -47,7 +47,10 @@ class League
         }
 
         $league->setFixtures(new FixtureSet($fixtures));
-        $league->setTable(new Table(BBCSportTableProvider::fromUrl($data['table']['url'], $league)));
+
+        if (isset($data['table'])) {
+            $league->setTable(new Table(BBCSportTableProvider::fromUrl($data['table']['url'], $league)));
+        }
 
         return $league;
 

--- a/src/Punkstar/RugbyFeed/League.php
+++ b/src/Punkstar/RugbyFeed/League.php
@@ -10,6 +10,8 @@ class League
     protected $fixtures;
     protected $table;
 
+    private $teamAliasCache = [];
+
     public function __construct($data, array $teams, FixtureSet $fixtures = null, Table $table = null)
     {
         $this->data = $data;
@@ -46,8 +48,13 @@ class League
      */
     public function getTeam($teamSearchString)
     {
-        foreach ($this->getTeams() as $team) {
+        if (isset($this->teamAliasCache[$teamSearchString])) {
+            return $this->getTeams()[$this->teamAliasCache[$teamSearchString]];
+        }
+
+        foreach ($this->getTeams() as $k => $team) {
             if ($team->isAliasedTo($teamSearchString)) {
+                $this->teamAliasCache[$teamSearchString] = $k;
                 return $team;
             }
         }

--- a/src/Punkstar/RugbyFeed/TableProvider/BBCSport.php
+++ b/src/Punkstar/RugbyFeed/TableProvider/BBCSport.php
@@ -28,6 +28,10 @@ class BBCSport implements TableProvider
         $this->league = $league;
     }
 
+    /**
+     * @return array|Row[]
+     * @throws \Exception
+     */
     public function getRows()
     {
         $document = new nokogiri($this->html);
@@ -41,6 +45,10 @@ class BBCSport implements TableProvider
             $tableRow->position = $row['td'][0]['#text'][0];
 
             $tableRow->team = $this->league->getTeam($this->getTeamFromRow($row));
+
+            if (is_null($tableRow->team)) {
+                throw new \Exception("Unable to recognise team in table");
+            }
 
             $tableRow->played = $row['td'][2]['#text'][0];
             $tableRow->won = $row['td'][3]['#text'][0];

--- a/src/Punkstar/RugbyFeed/TableProvider/BBCSport.php
+++ b/src/Punkstar/RugbyFeed/TableProvider/BBCSport.php
@@ -47,7 +47,7 @@ class BBCSport implements TableProvider
             $tableRow->team = $this->league->getTeam($this->getTeamFromRow($row));
 
             if (is_null($tableRow->team)) {
-                throw new \Exception("Unable to recognise team in table");
+                throw new \Exception("Unable to recognise team in table: " . $this->getTeamFromRow($row));
             }
 
             $tableRow->played = $row['td'][2]['#text'][0];

--- a/src/Punkstar/RugbyFeed/TableProvider/BBCSport.php
+++ b/src/Punkstar/RugbyFeed/TableProvider/BBCSport.php
@@ -5,22 +5,27 @@ namespace Punkstar\RugbyFeed\TableProvider;
 use nokogiri;
 use Punkstar\RugbyFeed\DataManager;
 use Punkstar\RugbyFeed\FileManager;
+use Punkstar\RugbyFeed\League;
 use Punkstar\RugbyFeed\Table\Row;
 use Punkstar\RugbyFeed\TableProvider;
 
 class BBCSport implements TableProvider
 {
 
-    private $html;
     /**
-     * @var null
+     * @var string
      */
-    private $dataManager;
+    private $html;
 
-    public function __construct($html, $dataManager = null)
+    /**
+     * @var League
+     */
+    private $league;
+
+    public function __construct($html, $league)
     {
         $this->html = $html;
-        $this->dataManager = $dataManager ?? new DataManager();
+        $this->league = $league;
     }
 
     public function getRows()
@@ -35,7 +40,7 @@ class BBCSport implements TableProvider
 
             $tableRow->position = $row['td'][0]['#text'][0];
 
-            $tableRow->team = $this->dataManager->getTeam($this->getTeamFromRow($row));
+            $tableRow->team = $this->league->getTeam($this->getTeamFromRow($row));
 
             $tableRow->played = $row['td'][2]['#text'][0];
             $tableRow->won = $row['td'][3]['#text'][0];
@@ -58,15 +63,16 @@ class BBCSport implements TableProvider
     }
 
     /**
-     * @param $url
+     * @param string $url
+     * @param League $league
      *
      * @throws \Exception
      * @return BBCSport
      */
-    public static function fromUrl($url, $dataManager = null)
+    public static function fromUrl(string $url, League $league)
     {
         $fm = new FileManager();
-        return new self($fm->getFileFromUrl($url), $dataManager);
+        return new self($fm->getFileFromUrl($url), $league);
     }
 
     protected function getTeamFromRow($row)

--- a/src/Punkstar/RugbyFeed/Team.php
+++ b/src/Punkstar/RugbyFeed/Team.php
@@ -15,7 +15,7 @@ class Team
     {
         $this->data = $data;
 
-        $this->url = $this->data['url'] ?? str_replace(' ', '_', strtolower($this->getName()));
+        $this->url = $this->data['url'] ?? str_replace(' ', '_', mb_strtolower($this->getName()));
     }
 
     /**
@@ -32,11 +32,11 @@ class Team
      */
     public function isAliasedTo($searchString)
     {
-        $aliases = array_map('strtolower', $this->data['alias'] ?? []);
-        $aliases[] = strtolower($this->getName());
+        $aliases = array_map('mb_strtolower', $this->data['alias'] ?? []);
+        $aliases[] = mb_strtolower($this->getName());
         $aliases[] = $this->getUrlKey();
 
-        return in_array(strtolower($searchString), $aliases);
+        return in_array(mb_strtolower($searchString), $aliases);
     }
 
     public function getName()

--- a/src/Punkstar/RugbyFeed/Team.php
+++ b/src/Punkstar/RugbyFeed/Team.php
@@ -4,23 +4,6 @@ namespace Punkstar\RugbyFeed;
 
 class Team
 {
-//    /**
-//     * @param $name
-//     * @return Team
-//     */
-//    public static function build($name)
-//    {
-//        foreach (self::$team_map as $team_key => $team_data) {
-//            $team_aliases = array_map('strtolower', $team_data['aliases']);
-//
-//            if (in_array(strtolower($name), $team_aliases)) {
-//                return new self($team_key);
-//            }
-//        }
-//
-//        return new self($name);
-//    }
-
     public function __construct($data)
     {
         $this->data = $data;
@@ -30,7 +13,7 @@ class Team
     {
         return $this->data['url'] ?? str_replace(' ', '_', strtolower($this->getName()));
     }
-    
+
     /**
      * @param $searchString
      * @return bool
@@ -40,10 +23,10 @@ class Team
         $aliases = array_map('strtolower', $this->data['alias'] ?? []);
         $aliases[] = strtolower($this->getName());
         $aliases[] = strtolower($this->getUrlKey());
-        
+
         return in_array(strtolower($searchString), $aliases);
     }
-    
+
     public function getName()
     {
         return $this->data['name'] ?? 'Unknown Name';
@@ -64,27 +47,4 @@ class Team
     {
         return $this->data['conference'] ?? '';
     }
-//
-//    /**
-//     * @param $alias
-//     * @return bool
-//     */
-//    public function isTeamAlias($alias)
-//    {
-//        return in_array(strtolower($alias), $this->getTeamAliases(), true);
-//    }
-//
-//    /**
-//     * Get lowercased valid team aliases.
-//     *
-//     * @return array
-//     */
-//    public function getTeamAliases()
-//    {
-//        $aliases = static::$team_map[$this->key]['aliases'];
-//        $aliases[] = $this->key;
-//        $aliases[] = $this->name;
-//
-//        return array_unique(array_map('strtolower', $aliases));
-//    }
 }

--- a/src/Punkstar/RugbyFeed/Team.php
+++ b/src/Punkstar/RugbyFeed/Team.php
@@ -4,14 +4,26 @@ namespace Punkstar\RugbyFeed;
 
 class Team
 {
+    private $data;
+
+    /**
+     * @var string
+     */
+    private $url;
+
     public function __construct($data)
     {
         $this->data = $data;
+
+        $this->url = $this->data['url'] ?? str_replace(' ', '_', strtolower($this->getName()));
     }
 
+    /**
+     * @return string
+     */
     public function getUrlKey()
     {
-        return $this->data['url'] ?? str_replace(' ', '_', strtolower($this->getName()));
+        return $this->url;
     }
 
     /**
@@ -22,7 +34,7 @@ class Team
     {
         $aliases = array_map('strtolower', $this->data['alias'] ?? []);
         $aliases[] = strtolower($this->getName());
-        $aliases[] = strtolower($this->getUrlKey());
+        $aliases[] = $this->getUrlKey();
 
         return in_array(strtolower($searchString), $aliases);
     }

--- a/src/Punkstar/RugbyFeedService/App.php
+++ b/src/Punkstar/RugbyFeedService/App.php
@@ -35,8 +35,6 @@ class App
         
             foreach ($leagues as $league) {
                 $fixtures_url = 'fixtures/' . $league->getUrlKey();
-                $table_url = 'table/' . $league->getUrlKey();
-            
                 $links[] = sprintf(
                     '<li><a href="%s">%s</a></li>',
                     $fixtures_url,
@@ -51,12 +49,15 @@ class App
                         $team_url
                     );
                 }
-            
-                $links[] = sprintf(
-                    '<li><a href="%s">%s</a></li>',
-                    $table_url,
-                    $table_url
-                );
+
+                if ($league->getTable()) {
+                    $table_url = 'table/' . $league->getUrlKey();
+                    $links[] = sprintf(
+                        '<li><a href="%s">%s</a></li>',
+                        $table_url,
+                        $table_url
+                    );
+                }
             }
         
             return "<h1>Available Resources</h1> " . implode("\n", $links);

--- a/src/Punkstar/RugbyFeedService/Controller/FixtureController.php
+++ b/src/Punkstar/RugbyFeedService/Controller/FixtureController.php
@@ -24,7 +24,7 @@ class FixtureController implements ControllerProviderInterface
 
             $data = new DataManager();
             $league = $data->getLeague($league_name_in_url);
-            
+
             if ($league === null) {
                 return new Response(
                     json_encode([
@@ -61,10 +61,10 @@ class FixtureController implements ControllerProviderInterface
         $controllers->get('/{league_name_in_url}/{team_name_in_url}', function (Application $app, $league_name_in_url, $team_name_in_url) {
             $fractal = new Manager();
             $fractal->setSerializer(new JsonApiSerializer());
-    
+
             $data = new DataManager();
             $league = $data->getLeague($league_name_in_url);
-    
+
             if ($league === null) {
                 return new Response(
                     json_encode([
@@ -83,9 +83,9 @@ class FixtureController implements ControllerProviderInterface
                     )
                 );
             }
-            
+
             $team = $league->getTeam($team_name_in_url);
-            
+
             if ($team != null) {
                 $data_container = new Collection(
                     $league->getFixturesForTeam($team),

--- a/src/Punkstar/RugbyFeedTest/FixtureProvider/BBCSportTest.php
+++ b/src/Punkstar/RugbyFeedTest/FixtureProvider/BBCSportTest.php
@@ -3,19 +3,35 @@
 namespace Punkstar\RugbyFeedTest\FixtureProvider;
 
 use PHPUnit\Framework\TestCase;
+use Punkstar\RugbyFeed\DataManager;
 use Punkstar\RugbyFeed\Fixture;
 use Punkstar\RugbyFeed\FixtureProvider\BBCSport;
+use Punkstar\RugbyFeed\League;
 
 class BBCSportTest extends TestCase
 {
 
     /**
+     * @var DataManager
+     */
+    private $dataManager;
+
+    /**
+     * @throws \Exception
+     */
+    public function setUp()
+    {
+        $this->dataManager = new DataManager();
+    }
+
+    /**
      * @test
+     * @throws \Exception
      */
     public function testExtractAvivaFixtures()
     {
         $html = file_get_contents($this->getAvivaFixturesDataFileName());
-        $parser = new BBCSport($html);
+        $parser = new BBCSport($html, $this->dataManager->getLeague('aviva'));
 
         $fixtures = $parser->getFixtures();
         $this->assertCount(2, $fixtures);
@@ -34,7 +50,7 @@ class BBCSportTest extends TestCase
     public function testExtractAvivaResults()
     {
         $html = file_get_contents($this->getAvivaResultsDataFileName());
-        $parser = new BBCSport($html);
+        $parser = new BBCSport($html, $this->dataManager->getLeague('aviva'));
 
         $fixtures = $parser->getFixtures();
 
@@ -56,7 +72,7 @@ class BBCSportTest extends TestCase
     public function testExtractPro14Fixtures()
     {
         $html = file_get_contents($this->getPro14FixturesDataFileName());
-        $parser = new BBCSport($html);
+        $parser = new BBCSport($html, $this->dataManager->getLeague('pro14'));
 
         $fixtures = $parser->getFixtures();
         $this->assertCount(3, $fixtures);
@@ -75,7 +91,7 @@ class BBCSportTest extends TestCase
     public function testExtractPro14Results()
     {
         $html = file_get_contents($this->getPro14ResultsDataFileName());
-        $parser = new BBCSport($html);
+        $parser = new BBCSport($html, $this->dataManager->getLeague('pro14'));
 
         $fixtures = $parser->getFixtures();
 

--- a/src/Punkstar/RugbyFeedTest/FixtureProvider/ICalTest.php
+++ b/src/Punkstar/RugbyFeedTest/FixtureProvider/ICalTest.php
@@ -3,10 +3,24 @@
 namespace Punkstar\RugbyFeedTest;
 
 use PHPUnit\Framework\TestCase;
+use Punkstar\RugbyFeed\DataManager;
 use Punkstar\RugbyFeed\FixtureProvider\ICal;
 
 class ICalTest extends TestCase
 {
+    /**
+     * @var DataManager
+     */
+    private $dataManager;
+
+    /**
+     * @throws \Exception
+     */
+    public function setUp()
+    {
+        $this->dataManager = new DataManager();
+    }
+
     /**
      * @test
      */
@@ -28,7 +42,9 @@ class ICalTest extends TestCase
             throw new \Exception("Could not read fixture file $file");
         }
 
-        return new ICal(file_get_contents($file));
+        $league = $this->dataManager->getLeague('aviva');
+
+        return new ICal(file_get_contents($file), $league);
     }
 
     protected function getAvivaFixtureDataFileName()

--- a/src/Punkstar/RugbyFeedTest/FixtureSetTest.php
+++ b/src/Punkstar/RugbyFeedTest/FixtureSetTest.php
@@ -3,12 +3,29 @@
 namespace Punkstar\RugbyFeedTest;
 
 use PHPUnit\Framework\TestCase;
+use Punkstar\RugbyFeed\DataManager;
 use Punkstar\RugbyFeed\FixtureProvider;
 use Punkstar\RugbyFeed\FixtureSet;
+use Punkstar\RugbyFeed\League;
 use Punkstar\RugbyFeed\Team;
 
 class FixtureSetTest extends TestCase
 {
+
+    /**
+     * @var DataManager
+     */
+    private $dataManager;
+
+    /**
+     * @throws \Exception
+     */
+    public function setUp()
+    {
+        $this->dataManager = new DataManager();
+    }
+
+
     /**
      * @test
      */
@@ -104,7 +121,9 @@ class FixtureSetTest extends TestCase
             throw new \Exception("Could not read fixture file $file");
         }
 
-        return new FixtureSet([new FixtureProvider\ICal(file_get_contents($file))]);
+        $league = $this->dataManager->getLeague('aviva');
+
+        return new FixtureSet([new FixtureProvider\ICal(file_get_contents($file), $league)]);
     }
 
     protected function getAvivaFixtureDataFileName()

--- a/src/Punkstar/RugbyFeedTest/FixtureTest.php
+++ b/src/Punkstar/RugbyFeedTest/FixtureTest.php
@@ -34,13 +34,13 @@ class FixtureTest extends TestCase
         $league = $this->dataManager->getLeague('aviva');
 
         $fixture = new Fixture(
+            $league,
             $home_team,
             $away_team,
+            $kickoff,
             $home_score,
             $away_score,
-            null,
-            $kickoff,
-            $league
+            null
         );
 
         $this->assertEquals($home_team, $fixture->getHomeTeam()->getName());
@@ -59,7 +59,8 @@ class FixtureTest extends TestCase
     public function testGetTeamsWithScores()
     {
         $data = array(
-            'SUMMARY' => 'Northampton Saints 53 - 6 Gloucester Rugby'
+            'SUMMARY' => 'Northampton Saints 53 - 6 Gloucester Rugby',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -77,7 +78,8 @@ class FixtureTest extends TestCase
     public function testGetTeamsWithoutScores()
     {
         $data = array(
-            'SUMMARY' => 'Newcastle Falcons v Harlequins'
+            'SUMMARY' => 'Newcastle Falcons v Harlequins',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -93,7 +95,8 @@ class FixtureTest extends TestCase
     public function testBtSportStripped()
     {
         $data = array(
-            'SUMMARY' => 'Harlequins v Saracens BT Sport'
+            'SUMMARY' => 'Harlequins v Saracens BT Sport',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -109,7 +112,8 @@ class FixtureTest extends TestCase
     public function testBbcNiStripped()
     {
         $data = array(
-            'SUMMARY' => 'Ulster Rugby v Edinburgh Rugby BBCNI/ALBA'
+            'SUMMARY' => 'Ulster Rugby v Edinburgh Rugby BBCNI/ALBA',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('pro14');
@@ -124,7 +128,8 @@ class FixtureTest extends TestCase
      */
     public function testTg4Stripped() {
         $data = array(
-            'SUMMARY' => 'Leinster Rugby v Glasgow Warriors TG4/BBC2SC'
+            'SUMMARY' => 'Leinster Rugby v Glasgow Warriors TG4/BBC2SC',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('pro14');
@@ -140,7 +145,8 @@ class FixtureTest extends TestCase
     public function testBbcWStripped()
     {
         $data = array(
-            'SUMMARY' => 'Cardiff Blues v Ospreys BBCW'
+            'SUMMARY' => 'Cardiff Blues v Ospreys BBCW',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('pro14');
@@ -157,7 +163,8 @@ class FixtureTest extends TestCase
     public function testGetScores()
     {
         $data = array(
-            'SUMMARY' => 'Newcastle Falcons 10 - 5 Harlequins'
+            'SUMMARY' => 'Newcastle Falcons 10 - 5 Harlequins',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -174,7 +181,8 @@ class FixtureTest extends TestCase
     public function testNoScoresAvailable()
     {
         $data = array(
-            'SUMMARY' => 'Newcastle Falcons v Harlequins'
+            'SUMMARY' => 'Newcastle Falcons v Harlequins',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -191,7 +199,8 @@ class FixtureTest extends TestCase
     public function testGameFinishedYes()
     {
         $data = array(
-            'SUMMARY' => 'Newcastle Falcons 10 - 5 Harlequins'
+            'SUMMARY' => 'Newcastle Falcons 10 - 5 Harlequins',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -207,7 +216,8 @@ class FixtureTest extends TestCase
     public function testGameFinishedNo()
     {
         $data = array(
-            'SUMMARY' => 'Newcastle Falcons v Harlequins'
+            'SUMMARY' => 'Newcastle Falcons v Harlequins',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -223,7 +233,9 @@ class FixtureTest extends TestCase
     public function testGetGameLocation()
     {
         $data = array(
-            'LOCATION' => 'Franklin\'s Gardens'
+            'SUMMARY' => 'Newcastle Falcons v Harlequins',
+            'LOCATION' => 'Franklin\'s Gardens',
+            'DTSTART' => '20140905T184500Z'
         );
 
         $league = $this->dataManager->getLeague('aviva');
@@ -238,6 +250,7 @@ class FixtureTest extends TestCase
     public function testGetKickOff()
     {
         $data = array(
+            'SUMMARY' => 'Newcastle Falcons v Harlequins',
             'DTSTART' => '20140905T184500Z'
         );
 

--- a/src/Punkstar/RugbyFeedTest/FixtureTest.php
+++ b/src/Punkstar/RugbyFeedTest/FixtureTest.php
@@ -3,10 +3,27 @@
 namespace Punkstar\RugbyFeedTest\Calendar;
 
 use PHPUnit\Framework\TestCase;
+use Punkstar\RugbyFeed\DataManager;
 use Punkstar\RugbyFeed\Fixture;
 
 class FixtureTest extends TestCase
 {
+    /**
+     * @var DataManager
+     */
+    private $dataManager;
+
+    /**
+     * @throws \Exception
+     */
+    public function setUp()
+    {
+        $this->dataManager = new DataManager();
+    }
+
+    /**
+     * @throws \Exception
+     */
     public function testConstruct()
     {
         $home_team = "Northampton Saints";
@@ -14,6 +31,7 @@ class FixtureTest extends TestCase
         $home_score = 53;
         $away_score = 6;
         $kickoff = strtotime("5th September 2014");
+        $league = $this->dataManager->getLeague('aviva');
 
         $fixture = new Fixture(
             $home_team,
@@ -21,7 +39,8 @@ class FixtureTest extends TestCase
             $home_score,
             $away_score,
             null,
-            $kickoff
+            $kickoff,
+            $league
         );
 
         $this->assertEquals($home_team, $fixture->getHomeTeam()->getName());
@@ -35,6 +54,7 @@ class FixtureTest extends TestCase
 
     /**
      * @test
+     * @throws \Exception
      */
     public function testGetTeamsWithScores()
     {
@@ -42,7 +62,9 @@ class FixtureTest extends TestCase
             'SUMMARY' => 'Northampton Saints 53 - 6 Gloucester Rugby'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals('Northampton Saints', $event->getHomeTeam()->getName());
         $this->assertEquals('Gloucester', $event->getAwayTeam()->getName());
@@ -50,6 +72,7 @@ class FixtureTest extends TestCase
 
     /**
      * @test
+     * @throws \Exception
      */
     public function testGetTeamsWithoutScores()
     {
@@ -57,54 +80,71 @@ class FixtureTest extends TestCase
             'SUMMARY' => 'Newcastle Falcons v Harlequins'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals('Newcastle Falcons', $event->getHomeTeam()->getName());
         $this->assertEquals('Harlequins', $event->getAwayTeam()->getName());
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testBtSportStripped()
     {
         $data = array(
             'SUMMARY' => 'Harlequins v Saracens BT Sport'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals('Harlequins', $event->getHomeTeam()->getName());
         $this->assertEquals('Saracens', $event->getAwayTeam()->getName());
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testBbcNiStripped()
     {
         $data = array(
             'SUMMARY' => 'Ulster Rugby v Edinburgh Rugby BBCNI/ALBA'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('pro14');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals('Ulster', $event->getHomeTeam()->getName());
         $this->assertEquals('Edinburgh', $event->getAwayTeam()->getName());
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testTg4Stripped() {
         $data = array(
             'SUMMARY' => 'Leinster Rugby v Glasgow Warriors TG4/BBC2SC'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('pro14');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals('Leinster', $event->getHomeTeam()->getName());
         $this->assertEquals('Glasgow', $event->getAwayTeam()->getName());
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testBbcWStripped()
     {
         $data = array(
             'SUMMARY' => 'Cardiff Blues v Ospreys BBCW'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('pro14');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals('Cardiff Blues', $event->getHomeTeam()->getName());
         $this->assertEquals('Ospreys', $event->getAwayTeam()->getName());
@@ -112,6 +152,7 @@ class FixtureTest extends TestCase
 
     /**
      * @test
+     * @throws \Exception
      */
     public function testGetScores()
     {
@@ -119,7 +160,8 @@ class FixtureTest extends TestCase
             'SUMMARY' => 'Newcastle Falcons 10 - 5 Harlequins'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals(10, $event->getHomeScore());
         $this->assertEquals(5, $event->getAwayScore());
@@ -127,6 +169,7 @@ class FixtureTest extends TestCase
 
     /**
      * @test
+     * @throws \Exception
      */
     public function testNoScoresAvailable()
     {
@@ -134,7 +177,8 @@ class FixtureTest extends TestCase
             'SUMMARY' => 'Newcastle Falcons v Harlequins'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertNull($event->getHomeScore());
         $this->assertNull($event->getAwayScore());
@@ -142,6 +186,7 @@ class FixtureTest extends TestCase
 
     /**
      * @test
+     * @throws \Exception
      */
     public function testGameFinishedYes()
     {
@@ -149,13 +194,15 @@ class FixtureTest extends TestCase
             'SUMMARY' => 'Newcastle Falcons 10 - 5 Harlequins'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertTrue($event->isGameFinished());
     }
 
     /**
      * @test
+     * @throws \Exception
      */
     public function testGameFinishedNo()
     {
@@ -163,13 +210,15 @@ class FixtureTest extends TestCase
             'SUMMARY' => 'Newcastle Falcons v Harlequins'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertFalse($event->isGameFinished());
     }
 
     /**
      * @test
+     * @throws \Exception
      */
     public function testGetGameLocation()
     {
@@ -177,18 +226,23 @@ class FixtureTest extends TestCase
             'LOCATION' => 'Franklin\'s Gardens'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals("Franklin's Gardens", $event->getLocation());
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testGetKickOff()
     {
         $data = array(
             'DTSTART' => '20140905T184500Z'
         );
 
-        $event = Fixture::buildFromArray($data);
+        $league = $this->dataManager->getLeague('aviva');
+        $event = Fixture::buildFromArray($data, $league);
 
         $this->assertEquals("Fri, 05 Sep 2014 18:45:00 +0000", $event->getKickoffDateTime()->format('r'));
     }

--- a/src/Punkstar/RugbyFeedTest/IntegrationTest.php
+++ b/src/Punkstar/RugbyFeedTest/IntegrationTest.php
@@ -39,8 +39,6 @@ class IntegrationTest extends TestCase
     
         foreach ($leagues as $league) {
             $fixtures_url = 'fixtures/' . $league->getUrlKey();
-            $table_url = 'table/' . $league->getUrlKey();
-            
             $routes[] = [$fixtures_url];
         
             foreach ($league->getTeams() as $team) {
@@ -48,9 +46,11 @@ class IntegrationTest extends TestCase
                 
                 $routes[] = [$team_url];
             }
-            
-    
-            $routes[] = [$table_url];
+
+            if ($league->getTable()) {
+                $table_url = 'table/' . $league->getUrlKey();
+                $routes[] = [$table_url];
+            }
         }
         
         return $routes;

--- a/src/Punkstar/RugbyFeedTest/IntegrationTest.php
+++ b/src/Punkstar/RugbyFeedTest/IntegrationTest.php
@@ -14,6 +14,7 @@ class IntegrationTest extends TestCase
     /**
      * @param $route
      * @dataProvider routeDataProvider
+     * @throws \Exception
      */
     public function testAllRoutesReturnSuccessfulResponse($route)
     {
@@ -27,6 +28,7 @@ class IntegrationTest extends TestCase
     
     /**
      * @return array
+     * @throws \Exception
      */
     public function routeDataProvider()
     {

--- a/src/Punkstar/RugbyFeedTest/TableProvider/BBCSportTest.php
+++ b/src/Punkstar/RugbyFeedTest/TableProvider/BBCSportTest.php
@@ -3,18 +3,34 @@
 namespace Punkstar\RugbyFeedTest\TableProvider;
 
 use PHPUnit\Framework\TestCase;
+use Punkstar\RugbyFeed\DataManager;
 use Punkstar\RugbyFeed\TableProvider\BBCSport;
 use Punkstar\RugbyFeed\Table\Row;
 
 class BBCSportTest extends TestCase
 {
     /**
+     * @var DataManager
+     */
+    private $dataManager;
+
+    /**
+     * @throws \Exception
+     */
+    public function setUp()
+    {
+        $this->dataManager = new DataManager();
+    }
+
+    /**
      * @test
+     * @throws \Exception
      */
     public function testExtractsRows()
     {
         $html = file_get_contents($this->getAvivaTableDataFileName());
-        $parser = new BBCSport($html);
+        $league = $this->dataManager->getLeague('aviva');
+        $parser = new BBCSport($html, $league);
 
         $this->assertCount(12, $parser->getRows());
     }
@@ -25,7 +41,8 @@ class BBCSportTest extends TestCase
     public function testRowPopulation()
     {
         $html = file_get_contents($this->getAvivaTableDataFileName());
-        $parser = new BBCSport($html);
+        $league = $this->dataManager->getLeague('aviva');
+        $parser = new BBCSport($html, $league);
 
         /** @var Row $first_row */
         $first_row = $parser->getRows()[0];
@@ -64,7 +81,8 @@ class BBCSportTest extends TestCase
     public function testForPro14()
     {
         $html = file_get_contents($this->getPro14TableDataFileName());
-        $parser = new BBCSport($html);
+        $league = $this->dataManager->getLeague('pro14');
+        $parser = new BBCSport($html, $league);
     
         $this->assertCount(14, $parser->getRows());
     


### PR DESCRIPTION
Added:

- Super Rugby
- French Top 14
- Six Nations
- Rugby Championship
- International Friendlies
- Champions Cup
- Challenge Cup

Added support for different teams being having the same aliases, e.g. "Blues" referencing Cardiff Blues and Super Rugby's Blues. 

Made table optional for leagues in case there isn't one, i.e. Internationals.

Minor performance improvements after blackfire analysis. The main one being to avoid loading all leagues unless absolutely necessary as this triggers fetching of results, fixtures and tables. 

Resolves #4.